### PR TITLE
[Feature] Add total shares retrieval method

### DIFF
--- a/liquidity_pool/src/contract.rs
+++ b/liquidity_pool/src/contract.rs
@@ -123,6 +123,10 @@ impl LiquidityPoolTrait for LiquidityPool {
         get_token_share(&e)
     }
 
+    fn get_total_shares(e: Env) -> u128 {
+        get_total_shares(&e)
+    }
+
     fn get_tokens(e: Env) -> Vec<Address> {
         Vec::from_array(&e, [get_token_a(&e), get_token_b(&e)])
     }

--- a/liquidity_pool/src/pool_interface.rs
+++ b/liquidity_pool/src/pool_interface.rs
@@ -30,6 +30,9 @@ pub trait LiquidityPoolTrait {
     // Returns the token contract address for the pool share token
     fn share_id(e: Env) -> Address;
 
+    // Returns the total amount of shares
+    fn get_total_shares(e: Env) -> u128;
+
     fn get_tokens(e: Env) -> Vec<Address>;
 
     // Deposits token_a and token_b. Also mints pool shares for the "to" Identifier. The amount minted

--- a/liquidity_pool_router/src/contract.rs
+++ b/liquidity_pool_router/src/contract.rs
@@ -51,6 +51,11 @@ impl LiquidityPoolInterfaceTrait for LiquidityPoolRouter {
         e.invoke_contract(&pool_id, &Symbol::new(&e, "share_id"), Vec::new(&e))
     }
 
+    fn get_total_shares(e: Env, tokens: Vec<Address>, pool_index: BytesN<32>) -> u128 {
+        let pool_id = get_pool(&e, tokens, pool_index).expect("Pool doesn't exist");
+        e.invoke_contract(&pool_id, &Symbol::new(&e, "get_total_shares"), Vec::new(&e))
+    }
+
     fn get_reserves(e: Env, tokens: Vec<Address>, pool_index: BytesN<32>) -> Vec<u128> {
         let pool_id = get_pool(&e, tokens, pool_index).expect("Pool doesn't exist");
         e.invoke_contract(&pool_id, &Symbol::new(&e, "get_reserves"), Vec::new(&e))

--- a/liquidity_pool_router/src/pool_interface.rs
+++ b/liquidity_pool_router/src/pool_interface.rs
@@ -13,6 +13,9 @@ pub trait LiquidityPoolInterfaceTrait {
     // Returns the token contract address for the pool share token.
     fn share_id(e: Env, tokens: Vec<Address>, pool_index: BytesN<32>) -> Address;
 
+    // Returns the total amount of shares
+    fn get_total_shares(e: Env, tokens: Vec<Address>, pool_index: BytesN<32>) -> u128;
+
     // Getter for the pool balances array.
     fn get_reserves(e: Env, tokens: Vec<Address>, pool_index: BytesN<32>) -> Vec<u128>;
 

--- a/liquidity_pool_router/src/test.rs
+++ b/liquidity_pool_router/src/test.rs
@@ -173,6 +173,7 @@ fn test_constant_product_pool() {
     router.deposit(&user1, &tokens, &pool_hash, &desired_amounts);
 
     assert_eq!(token_share.balance(&user1), 100);
+    assert_eq!(router.get_total_shares(&tokens, &pool_hash), 100);
     assert_eq!(token_share.balance(&pool_address), 0);
     assert_eq!(token1.balance(&user1), 900);
     assert_eq!(token1.balance(&pool_address), 100);
@@ -475,6 +476,7 @@ fn test_stableswap_pool() {
     router.deposit(&user1, &tokens, &pool_hash, &desired_amounts);
 
     assert_eq!(token_share.balance(&user1), 200_0000000);
+    assert_eq!(router.get_total_shares(&tokens, &pool_hash), 200_0000000);
     assert_eq!(token_share.balance(&pool_address), 0);
     assert_eq!(token1.balance(&user1), 900_0000000);
     assert_eq!(token1.balance(&pool_address), 100_0000000);

--- a/liquidity_pool_stableswap/src/contract.rs
+++ b/liquidity_pool_stableswap/src/contract.rs
@@ -789,6 +789,10 @@ impl LiquidityPoolInterfaceTrait for LiquidityPool {
         get_token_share(&e)
     }
 
+    fn get_total_shares(e: Env) -> u128 {
+        get_total_shares(&e)
+    }
+
     fn get_reserves(e: Env) -> Vec<u128> {
         get_reserves(&e)
     }

--- a/liquidity_pool_stableswap/src/pool_interface.rs
+++ b/liquidity_pool_stableswap/src/pool_interface.rs
@@ -40,6 +40,9 @@ pub trait LiquidityPoolInterfaceTrait {
     // Returns the token contract address for the pool share token
     fn share_id(e: Env) -> Address;
 
+    // Returns the total amount of shares
+    fn get_total_shares(e: Env) -> u128;
+
     // Getter for the pool balances array.
     fn get_reserves(e: Env) -> Vec<u128>;
 


### PR DESCRIPTION
A new method, `get_total_shares()`, has been implemented across various modules for fetching the total shares in a pool. This method uses the provided identifiers to return cumulative shares, improving accessibility of this information. Updates to tests ensure the functionality's correctness.