### PR TITLE
[Bugfix] Fix contant product swap math & ensure pool fee is fair

### DIFF
--- a/liquidity_pool/src/contract.rs
+++ b/liquidity_pool/src/contract.rs
@@ -265,7 +265,7 @@ impl LiquidityPoolTrait for LiquidityPool {
 
         // residue_numerator and residue_denominator are the amount that the invariant considers after
         // deducting the fee, scaled up by FEE_MULTIPLIER to avoid fractions
-        let residue_numerator = FEE_MULTIPLIER - fee_fraction as u128;
+        let residue_numerator = FEE_MULTIPLIER - (get_fee_fraction(&e) as u128);
         let residue_denominator = U256::from_u128(&e, FEE_MULTIPLIER);
 
         let new_invariant_factor = |balance: u128, reserve: u128, out: u128| {

--- a/liquidity_pool/src/contract.rs
+++ b/liquidity_pool/src/contract.rs
@@ -26,7 +26,6 @@ use token_share::{
     mint_shares, put_token_share, Client as LPTokenClient,
 };
 use utils::bump::bump_instance;
-use utils::math_errors::MathError;
 use utils::u256_math::ExtraMath;
 
 // Metadata that is added on to the WASM custom section

--- a/liquidity_pool/src/contract.rs
+++ b/liquidity_pool/src/contract.rs
@@ -3,6 +3,7 @@ use crate::errors::LiquidityPoolError;
 use crate::plane::update_plane;
 use crate::plane_interface::Plane;
 use crate::pool;
+use crate::pool::get_amount_out;
 use crate::pool_interface::{
     LiquidityPoolCrunch, LiquidityPoolTrait, RewardsTrait, UpgradeableContractTrait,
 };
@@ -249,10 +250,7 @@ impl LiquidityPoolTrait for LiquidityPool {
             panic_with_error!(&e, LiquidityPoolValidationError::EmptyPool);
         }
 
-        let fee_fraction = get_fee_fraction(&e);
-        let result = in_amount.fixed_mul_floor(&e, reserve_buy, reserve_sell + in_amount);
-        let fee = result.fixed_mul_ceil(&e, fee_fraction as u128, FEE_MULTIPLIER);
-        let out = result - fee;
+        let out = get_amount_out(&e, in_amount, reserve_sell, reserve_buy);
 
         if out < out_min {
             panic_with_error!(&e, LiquidityPoolValidationError::OutMinNotSatisfied);
@@ -329,10 +327,7 @@ impl LiquidityPoolTrait for LiquidityPool {
         let reserve_sell = reserves.get(in_idx).unwrap();
         let reserve_buy = reserves.get(out_idx).unwrap();
 
-        let fee_fraction = get_fee_fraction(&e);
-        let result = in_amount.fixed_mul_floor(&e, reserve_buy, reserve_sell + in_amount);
-        let fee = result.fixed_mul_ceil(&e, fee_fraction as u128, FEE_MULTIPLIER);
-        result - fee
+        get_amount_out(&e, in_amount, reserve_sell, reserve_buy)
     }
 
     fn withdraw(e: Env, user: Address, share_amount: u128, min_amounts: Vec<u128>) -> Vec<u128> {

--- a/liquidity_pool/src/pool.rs
+++ b/liquidity_pool/src/pool.rs
@@ -1,3 +1,5 @@
+use crate::constants::FEE_MULTIPLIER;
+use crate::storage::get_fee_fraction;
 use liquidity_pool_validation_errors::LiquidityPoolValidationError;
 use soroban_fixed_point_math::SorobanFixedPoint;
 use soroban_sdk::{panic_with_error, Env};
@@ -28,4 +30,16 @@ pub fn get_deposit_amounts(
         }
         (amount_a, desired_b)
     }
+}
+
+pub fn get_amount_out(e: &Env, in_amount: u128, reserve_sell: u128, reserve_buy: u128) -> u128 {
+    if in_amount == 0 {
+        return 0;
+    }
+
+    // in * reserve_buy / (reserve_sell + in) - fee
+    let fee_fraction = get_fee_fraction(&e);
+    let result = in_amount.fixed_mul_floor(&e, reserve_buy, reserve_sell + in_amount);
+    let fee = result.fixed_mul_ceil(&e, fee_fraction as u128, FEE_MULTIPLIER);
+    result - fee
 }

--- a/liquidity_pool_router/src/test.rs
+++ b/liquidity_pool_router/src/test.rs
@@ -544,18 +544,18 @@ fn test_stableswap_pool() {
             &token2.address,
             &pool_hash,
             &97_0000000_u128,
-            &80_4573706_u128,
+            &80_4573705_u128,
         ),
-        80_4573706
+        80_4573705
     );
 
     assert_eq!(token1.balance(&user1), 803_0000000);
     assert_eq!(token1.balance(&pool_address), 197_0000000);
-    assert_eq!(token2.balance(&user1), 980_4573706);
-    assert_eq!(token2.balance(&pool_address), 19_5426294);
+    assert_eq!(token2.balance(&user1), 980_4573705);
+    assert_eq!(token2.balance(&pool_address), 19_5426295);
     assert_eq!(
         router.get_reserves(&tokens, &pool_hash),
-        Vec::from_array(&e, [197_0000000, 19_5426294])
+        Vec::from_array(&e, [197_0000000, 19_5426295])
     );
 
     router.withdraw(
@@ -697,7 +697,7 @@ fn test_stableswap_3_pool() {
     );
     assert_eq!(
         router.estimate_swap_routed(&tokens, &token1.address, &token2.address, &97_0000000,),
-        (pool_hash.clone(), pool_address.clone(), 80_4573706),
+        (pool_hash.clone(), pool_address.clone(), 80_4573705),
     );
     assert_eq!(
         router.swap(
@@ -707,9 +707,13 @@ fn test_stableswap_3_pool() {
             &token2.address,
             &pool_hash,
             &97_0000000_u128,
-            &80_4573706_u128,
+            &80_4573705_u128,
         ),
-        80_4573706
+        80_4573705
+    );
+    assert_eq!(
+        router.estimate_swap_routed(&tokens, &token2.address, &token3.address, &20_0000000,),
+        (pool_hash.clone(), pool_address.clone(), 28_0695119),
     );
     assert_eq!(
         router.swap(
@@ -719,20 +723,20 @@ fn test_stableswap_3_pool() {
             &token3.address,
             &pool_hash,
             &20_0000000_u128,
-            &28_0695121_u128,
+            &28_0695119_u128,
         ),
-        28_0695121
+        28_0695119
     );
 
     assert_eq!(token1.balance(&user1), 803_0000000);
     assert_eq!(token1.balance(&pool_address), 197_0000000);
-    assert_eq!(token2.balance(&user1), 960_4573706);
-    assert_eq!(token2.balance(&pool_address), 39_5426294);
-    assert_eq!(token3.balance(&user1), 928_0695121);
-    assert_eq!(token3.balance(&pool_address), 71_9304879);
+    assert_eq!(token2.balance(&user1), 960_4573705);
+    assert_eq!(token2.balance(&pool_address), 39_5426295);
+    assert_eq!(token3.balance(&user1), 928_0695119);
+    assert_eq!(token3.balance(&pool_address), 71_9304881);
     assert_eq!(
         router.get_reserves(&tokens, &pool_hash),
-        Vec::from_array(&e, [197_0000000, 39_5426294, 71_9304879])
+        Vec::from_array(&e, [197_0000000, 39_5426295, 71_9304881])
     );
 
     router.withdraw(
@@ -740,7 +744,7 @@ fn test_stableswap_3_pool() {
         &tokens,
         &pool_hash,
         &300_0000000_u128,
-        &Vec::from_array(&e, [197_0000000_u128, 39_5426294, 71_9304879]),
+        &Vec::from_array(&e, [197_0000000_u128, 39_5426295, 71_9304881]),
     );
 
     assert_eq!(token1.balance(&user1), 1000_0000000);
@@ -1223,7 +1227,7 @@ fn test_swap_routed() {
     e.budget().print();
     assert_eq!(best_pool, stable1_pool_hash);
     assert_eq!(best_pool_address, stable1_pool_address);
-    assert_eq!(best_result, 8_9936586);
+    assert_eq!(best_result, 8_9936585);
 }
 
 #[test]

--- a/liquidity_pool_router/src/test.rs
+++ b/liquidity_pool_router/src/test.rs
@@ -185,11 +185,11 @@ fn test_constant_product_pool() {
 
     assert_eq!(
         router.estimate_swap(&tokens, &token1.address, &token2.address, &pool_hash, &97),
-        49
+        48
     );
     assert_eq!(
         router.estimate_swap_routed(&tokens, &token1.address, &token2.address, &97),
-        (pool_hash.clone(), pool_address.clone(), 49),
+        (pool_hash.clone(), pool_address.clone(), 48),
     );
     assert_eq!(
         router.swap(
@@ -199,18 +199,18 @@ fn test_constant_product_pool() {
             &token2.address,
             &pool_hash,
             &97_u128,
-            &49_u128,
+            &48_u128,
         ),
-        49
+        48
     );
 
     assert_eq!(token1.balance(&user1), 803);
     assert_eq!(token1.balance(&pool_address), 197);
-    assert_eq!(token2.balance(&user1), 949);
-    assert_eq!(token2.balance(&pool_address), 51);
+    assert_eq!(token2.balance(&user1), 948);
+    assert_eq!(token2.balance(&pool_address), 52);
     assert_eq!(
         router.get_reserves(&tokens, &pool_hash),
-        Vec::from_array(&e, [197, 51])
+        Vec::from_array(&e, [197, 52])
     );
 
     router.withdraw(
@@ -218,7 +218,7 @@ fn test_constant_product_pool() {
         &tokens,
         &pool_hash,
         &100_u128,
-        &Vec::from_array(&e, [197_u128, 51_u128]),
+        &Vec::from_array(&e, [197_u128, 52_u128]),
     );
 
     assert_eq!(token1.balance(&user1), 1000);
@@ -534,7 +534,7 @@ fn test_stableswap_pool() {
             &pool_hash,
             &97_0000000,
         ),
-        80_4573706
+        80_4573705
     );
     assert_eq!(
         router.swap(
@@ -693,7 +693,7 @@ fn test_stableswap_3_pool() {
             &pool_hash,
             &97_0000000,
         ),
-        80_4573706
+        80_4573705
     );
     assert_eq!(
         router.estimate_swap_routed(&tokens, &token1.address, &token2.address, &97_0000000,),
@@ -1067,7 +1067,7 @@ fn test_event_correct() {
         &token2.address,
         &pool_hash,
         &97_u128,
-        &49_u128,
+        &48_u128,
     );
     let swap_event = e.events().all().last().unwrap();
 

--- a/liquidity_pool_stableswap/src/contract.rs
+++ b/liquidity_pool_stableswap/src/contract.rs
@@ -112,7 +112,7 @@ impl LiquidityPoolTrait for LiquidityPool {
         }
 
         let dy = (xp.get(j).unwrap() - y - 1).fixed_mul_floor(&e, PRECISION, rates[j as usize]);
-        let fee = (get_fee(&e) as u128).fixed_mul_floor(&e, dy, FEE_DENOMINATOR as u128);
+        let fee = (get_fee(&e) as u128).fixed_mul_ceil(&e, dy, FEE_DENOMINATOR as u128);
         dy - fee
     }
 
@@ -124,7 +124,7 @@ impl LiquidityPoolTrait for LiquidityPool {
         let x = xp.get(i).unwrap() + dx * precisions[i as usize];
         let y = Self::get_y(e.clone(), i, j, x, xp.clone());
         let dy = (xp.get(j).unwrap() - y - 1) / precisions[j as usize];
-        let fee = (get_fee(&e) as u128).fixed_mul_floor(&e, dy, FEE_DENOMINATOR as u128);
+        let fee = (get_fee(&e) as u128).fixed_mul_ceil(&e, dy, FEE_DENOMINATOR as u128);
         dy - fee
     }
 
@@ -159,7 +159,7 @@ impl LiquidityPoolTrait for LiquidityPool {
             panic_with_error!(&e, LiquidityPoolValidationError::EmptyPool);
         }
         let fee =
-            (get_fee(&e) as u128).fixed_mul_floor(&e, N_COINS as u128, 4 * (N_COINS as u128 - 1));
+            (get_fee(&e) as u128).fixed_mul_ceil(&e, N_COINS as u128, 4 * (N_COINS as u128 - 1));
         let admin_fee = get_admin_fee(&e) as u128;
         let amp = Self::a(e.clone());
         let mut reserves = get_reserves(&e);

--- a/liquidity_pool_stableswap/src/contract.rs
+++ b/liquidity_pool_stableswap/src/contract.rs
@@ -939,8 +939,8 @@ impl LiquidityPoolInterfaceTrait for LiquidityPool {
 
                 let fee = difference.fixed_mul_ceil(
                     &e,
-                    get_fee(&e) as u128 * N_COINS as u128,
-                    FEE_DENOMINATOR as u128 * 4 * (N_COINS as u128 - 1),
+                    get_fee(&e) as u128 * n_coins as u128,
+                    FEE_DENOMINATOR as u128 * 4 * (n_coins as u128 - 1),
                 );
                 fees.push_back(fee);
 

--- a/liquidity_pool_stableswap/src/test.rs
+++ b/liquidity_pool_stableswap/src/test.rs
@@ -166,8 +166,8 @@ fn test_happy_flow() {
 
     assert_eq!(token1.balance(&user1) as u128, 790_0000000);
     assert_eq!(token1.balance(&liqpool.address) as u128, 210_0000000);
-    assert_eq!(token2.balance(&user1) as u128, 807_9637267);
-    assert_eq!(token2.balance(&liqpool.address) as u128, 192_0362733);
+    assert_eq!(token2.balance(&user1) as u128, 807_9637266);
+    assert_eq!(token2.balance(&liqpool.address) as u128, 192_0362734);
 
     liqpool.withdraw(
         &user1,
@@ -424,8 +424,8 @@ fn test_happy_flow_3_tokens() {
 
     assert_eq!(token1.balance(&user1) as u128, 790_0000000);
     assert_eq!(token1.balance(&liqpool.address) as u128, 210_0000000);
-    assert_eq!(token2.balance(&user1) as u128, 807_9637267);
-    assert_eq!(token2.balance(&liqpool.address) as u128, 192_0362733);
+    assert_eq!(token2.balance(&user1) as u128, 807_9637266);
+    assert_eq!(token2.balance(&liqpool.address) as u128, 192_0362734);
     assert_eq!(token3.balance(&user1) as u128, 800_0000000);
     assert_eq!(token3.balance(&liqpool.address) as u128, 200_0000000);
 
@@ -433,8 +433,8 @@ fn test_happy_flow_3_tokens() {
 
     assert_eq!(token1.balance(&user1) as u128, 805_9304412);
     assert_eq!(token1.balance(&liqpool.address) as u128, 194_0695588);
-    assert_eq!(token2.balance(&user1) as u128, 807_9637267);
-    assert_eq!(token2.balance(&liqpool.address) as u128, 192_0362733);
+    assert_eq!(token2.balance(&user1) as u128, 807_9637266);
+    assert_eq!(token2.balance(&liqpool.address) as u128, 192_0362734);
     assert_eq!(token3.balance(&user1) as u128, 780_0000000);
     assert_eq!(token3.balance(&liqpool.address) as u128, 220_0000000);
 
@@ -567,8 +567,8 @@ fn test_happy_flow_4_tokens() {
 
     assert_eq!(token1.balance(&user1) as u128, 790_0000000);
     assert_eq!(token1.balance(&liqpool.address) as u128, 210_0000000);
-    assert_eq!(token2.balance(&user1) as u128, 807_9637267);
-    assert_eq!(token2.balance(&liqpool.address) as u128, 192_0362733);
+    assert_eq!(token2.balance(&user1) as u128, 807_9637266);
+    assert_eq!(token2.balance(&liqpool.address) as u128, 192_0362734);
     assert_eq!(token3.balance(&user1) as u128, 800_0000000);
     assert_eq!(token3.balance(&liqpool.address) as u128, 200_0000000);
     assert_eq!(token4.balance(&user1) as u128, 800_0000000);
@@ -576,10 +576,10 @@ fn test_happy_flow_4_tokens() {
 
     liqpool.swap(&user1, &3, &0, &20_0000000, &1_0000000);
 
-    assert_eq!(token1.balance(&user1) as u128, 805_9304932);
-    assert_eq!(token1.balance(&liqpool.address) as u128, 194_0695068);
-    assert_eq!(token2.balance(&user1) as u128, 807_9637267);
-    assert_eq!(token2.balance(&liqpool.address) as u128, 192_0362733);
+    assert_eq!(token1.balance(&user1) as u128, 805_9304931);
+    assert_eq!(token1.balance(&liqpool.address) as u128, 194_0695069);
+    assert_eq!(token2.balance(&user1) as u128, 807_9637266);
+    assert_eq!(token2.balance(&liqpool.address) as u128, 192_0362734);
     assert_eq!(token3.balance(&user1) as u128, 800_0000000);
     assert_eq!(token3.balance(&liqpool.address) as u128, 200_0000000);
     assert_eq!(token4.balance(&user1) as u128, 780_0000000);
@@ -768,19 +768,19 @@ fn test_custom_fee() {
     // we're checking fraction against value required to swap 1 token
     for fee_config in [
         (0, 0, 9990916, 0, 0),           // fee = 0%, admin fee = 0%
-        (10, 0, 9980926, 0, 0),          // fee = 0.1%, admin fee = 0%
-        (30, 0, 9960944, 0, 0),          // fee = 0.3%, admin fee = 0%
-        (100, 0, 9891007, 0, 0),         // fee = 1%, admin fee = 0%
-        (1000, 0, 8991825, 0, 0),        // fee = 10%, admin fee = 0%
-        (3000, 0, 6993642, 0, 0),        // fee = 30%, admin fee = 0%
-        (9900, 0, 99910, 0, 0),          // fee = 99%, admin fee = 0%
-        (9999, 0, 1000, 0, 0),           // fee = 99.99% - maximum fee, admin fee = 0%
-        (100, 10, 9891007, 0, 99),       // fee = 0.1%, admin fee = 0.1%
-        (100, 100, 9891007, 0, 999),     // fee = 0.1%, admin fee = 1%
-        (100, 1000, 9891007, 0, 9990),   // fee = 0.1%, admin fee = 10%
-        (100, 2000, 9891007, 0, 19981),  // fee = 0.1%, admin fee = 20%
-        (100, 5000, 9891007, 0, 49954),  // fee = 0.1%, admin fee = 50%
-        (100, 10000, 9891007, 0, 99909), // fee = 0.1%, admin fee = 100%
+        (10, 0, 9980925, 0, 0),          // fee = 0.1%, admin fee = 0%
+        (30, 0, 9960943, 0, 0),          // fee = 0.3%, admin fee = 0%
+        (100, 0, 9891006, 0, 0),         // fee = 1%, admin fee = 0%
+        (1000, 0, 8991824, 0, 0),        // fee = 10%, admin fee = 0%
+        (3000, 0, 6993641, 0, 0),        // fee = 30%, admin fee = 0%
+        (9900, 0, 99909, 0, 0),          // fee = 99%, admin fee = 0%
+        (9999, 0, 999, 0, 0),            // fee = 99.99% - maximum fee, admin fee = 0%
+        (100, 10, 9891006, 0, 100),      // fee = 0.1%, admin fee = 0.1%
+        (100, 100, 9891006, 0, 1000),    // fee = 0.1%, admin fee = 1%
+        (100, 1000, 9891006, 0, 9991),   // fee = 0.1%, admin fee = 10%
+        (100, 2000, 9891006, 0, 19982),  // fee = 0.1%, admin fee = 20%
+        (100, 5000, 9891006, 0, 49955),  // fee = 0.1%, admin fee = 50%
+        (100, 10000, 9891006, 0, 99910), // fee = 0.1%, admin fee = 100%
     ] {
         let plane = create_plane_contract(&e);
         let liqpool = create_liqpool_contract(

--- a/liquidity_pool_swap_router/src/stableswap_pool.rs
+++ b/liquidity_pool_swap_router/src/stableswap_pool.rs
@@ -156,7 +156,7 @@ fn get_dy(
     }
 
     let dy = (xp.get(j).unwrap() - y - 1).fixed_mul_floor(e, PRECISION, RATE);
-    let fee = fee_fraction.fixed_mul_floor(e, dy, FEE_DENOMINATOR as u128);
+    let fee = fee_fraction.fixed_mul_ceil(e, dy, FEE_DENOMINATOR as u128);
     dy - fee
 }
 

--- a/liquidity_pool_swap_router/src/test.rs
+++ b/liquidity_pool_swap_router/src/test.rs
@@ -113,7 +113,7 @@ fn test() {
     e.budget().print();
     e.budget().reset_unlimited();
     assert_eq!(best_pool, address5);
-    assert_eq!(best_result, 41_8273777);
+    assert_eq!(best_result, 41_8273776);
 }
 
 #[test]
@@ -302,7 +302,7 @@ fn test_3_tokens() {
         &1_0000000,
     );
     assert_eq!(best_pool, address4);
-    assert_eq!(best_result, 9982278);
+    assert_eq!(best_result, 9982277);
 }
 
 #[test]


### PR DESCRIPTION
Fix constant product swap math - don't apply fee multiplier to denominator (instead of `y=x*b*(1-fee)/(a+x)` there was `y=x*b*(1-fee)/(a+x*(1-fee))`)

The refactoring includes using mul_ceil instead of mul_floor for fee calculation to ensure that users cannot exploit rounding to get a better rate. This prevents potential manipulation and makes the swap process fairer.