### PR TITLE
[Chore] LP token migration cleanup

### DIFF
--- a/liquidity_pool/src/contract.rs
+++ b/liquidity_pool/src/contract.rs
@@ -29,8 +29,7 @@ use soroban_sdk::{
     IntoVal, Map, Symbol, Val, Vec, U256,
 };
 use token_share::{
-    burn_shares, get_token_share,
-    get_total_shares, get_user_balance_shares, mint_shares,
+    burn_shares, get_token_share, get_total_shares, get_user_balance_shares, mint_shares,
     put_token_share, Client as LPTokenClient,
 };
 use utils::u256_math::ExtraMath;

--- a/liquidity_pool/src/contract.rs
+++ b/liquidity_pool/src/contract.rs
@@ -29,9 +29,9 @@ use soroban_sdk::{
     IntoVal, Map, Symbol, Val, Vec, U256,
 };
 use token_share::{
-    burn_shares, commit_future_token_share, get_future_token_share, get_token_share,
-    get_total_shares, get_user_balance_shares, mint_shares, put_future_token_share,
-    put_token_share, replicate_token_share_balance_to_future, Client as LPTokenClient,
+    burn_shares, get_token_share,
+    get_total_shares, get_user_balance_shares, mint_shares,
+    put_token_share, Client as LPTokenClient,
 };
 use utils::u256_math::ExtraMath;
 
@@ -291,9 +291,6 @@ impl LiquidityPoolTrait for LiquidityPool {
         // update plane data for every pool update
         update_plane(&e);
 
-        // migrate user shares if future token share contract is available
-        replicate_token_share_balance_to_future(&e, &user);
-
         let amounts_vec = Vec::from_array(&e, [amounts.0, amounts.1]);
         PoolEvents::new(&e).deposit_liquidity(
             Self::get_tokens(e.clone()),
@@ -420,9 +417,6 @@ impl LiquidityPoolTrait for LiquidityPool {
         // update plane data for every pool update
         update_plane(&e);
 
-        // migrate user shares if future token share contract is available
-        replicate_token_share_balance_to_future(&e, &user);
-
         PoolEvents::new(&e).trade(
             user,
             sell_token,
@@ -519,9 +513,6 @@ impl LiquidityPoolTrait for LiquidityPool {
 
         // update plane data for every pool update
         update_plane(&e);
-
-        // migrate user shares if future token share contract is available
-        replicate_token_share_balance_to_future(&e, &user);
 
         let withdraw_amounts = Vec::from_array(&e, [out_a, out_b]);
         PoolEvents::new(&e).withdraw_liquidity(
@@ -725,38 +716,6 @@ impl UpgradeableLPTokenTrait for LiquidityPool {
 
         let share_contract = get_token_share(&e);
         token_share::Client::new(&e, &share_contract).upgrade(&new_token_wasm);
-    }
-
-    fn set_future_share_id(e: Env, admin: Address, contract: Address) {
-        admin.require_auth();
-        AccessControl::new(&e).check_admin(&admin);
-
-        put_future_token_share(&e, contract);
-    }
-
-    fn migrate_share_balances(e: Env, operator: Address, users: Vec<Address>) {
-        operator.require_auth();
-        AccessControl::new(&e).check_operator(&operator);
-
-        for user in users {
-            replicate_token_share_balance_to_future(&e, &user);
-        }
-    }
-
-    // Returns the future share token address.
-    fn get_future_share_id(e: Env) -> Address {
-        match get_future_token_share(&e) {
-            Some(address) => address,
-            None => panic_with_error!(e, LiquidityPoolError::FutureShareIdNotSet),
-        }
-    }
-
-    // Applies the future share token instead of the current one.
-    fn commit_future_share_id(e: Env, admin: Address) {
-        admin.require_auth();
-        AccessControl::new(&e).check_admin(&admin);
-
-        commit_future_token_share(&e);
     }
 }
 

--- a/liquidity_pool/src/pool_interface.rs
+++ b/liquidity_pool/src/pool_interface.rs
@@ -115,10 +115,6 @@ pub trait UpgradeableContractTrait {
 
 pub trait UpgradeableLPTokenTrait {
     fn upgrade_token(e: Env, admin: Address, new_token_wasm: BytesN<32>);
-    fn set_future_share_id(e: Env, admin: Address, contract: Address);
-    fn migrate_share_balances(e: Env, operator: Address, users: Vec<Address>);
-    fn get_future_share_id(e: Env) -> Address;
-    fn commit_future_share_id(e: Env, admin: Address);
 }
 
 pub trait RewardsTrait {

--- a/liquidity_pool_stableswap/src/contract.rs
+++ b/liquidity_pool_stableswap/src/contract.rs
@@ -17,8 +17,7 @@ use crate::storage::{
 };
 use crate::token::create_contract;
 use token_share::{
-    burn_shares, get_token_share,
-    get_total_shares, get_user_balance_shares, mint_shares,
+    burn_shares, get_token_share, get_total_shares, get_user_balance_shares, mint_shares,
     put_token_share, Client as LPToken,
 };
 

--- a/liquidity_pool_stableswap/src/contract.rs
+++ b/liquidity_pool_stableswap/src/contract.rs
@@ -17,9 +17,9 @@ use crate::storage::{
 };
 use crate::token::create_contract;
 use token_share::{
-    burn_shares, commit_future_token_share, get_future_token_share, get_token_share,
-    get_total_shares, get_user_balance_shares, mint_shares, put_future_token_share,
-    put_token_share, replicate_token_share_balance_to_future, Client as LPToken,
+    burn_shares, get_token_share,
+    get_total_shares, get_user_balance_shares, mint_shares,
+    put_token_share, Client as LPToken,
 };
 
 use crate::errors::LiquidityPoolError;
@@ -330,9 +330,6 @@ impl LiquidityPoolTrait for LiquidityPool {
 
         // update plane data for every pool update
         update_plane(&e);
-
-        // migrate user shares if future token share contract is available
-        replicate_token_share_balance_to_future(&e, &user);
 
         let mut amounts: Vec<u128> = Vec::new(&e);
         for token_idx in 0..coins.len() {
@@ -1193,9 +1190,6 @@ impl LiquidityPoolInterfaceTrait for LiquidityPool {
         // update plane data for every pool update
         update_plane(&e);
 
-        // migrate user shares if future token share contract is available
-        replicate_token_share_balance_to_future(&e, &user);
-
         PoolEvents::new(&e).deposit_liquidity(tokens, amounts.clone(), mint_amount);
 
         (amounts, mint_amount)
@@ -1270,9 +1264,6 @@ impl LiquidityPoolInterfaceTrait for LiquidityPool {
 
         // update plane data for every pool update
         update_plane(&e);
-
-        // migrate user shares if future token share contract is available
-        replicate_token_share_balance_to_future(&e, &user);
 
         PoolEvents::new(&e).trade(user, input_coin, token_out, in_amount, dy, dy_fee);
 
@@ -1352,9 +1343,6 @@ impl LiquidityPoolInterfaceTrait for LiquidityPool {
         // update plane data for every pool update
         update_plane(&e);
 
-        // migrate user shares if future token share contract is available
-        replicate_token_share_balance_to_future(&e, &user);
-
         PoolEvents::new(&e).withdraw_liquidity(tokens, amounts.clone(), share_amount);
 
         amounts
@@ -1412,38 +1400,6 @@ impl UpgradeableLPTokenTrait for LiquidityPool {
 
         let share_contract = get_token_share(&e);
         token_share::Client::new(&e, &share_contract).upgrade(&new_token_wasm);
-    }
-
-    fn set_future_share_id(e: Env, admin: Address, contract: Address) {
-        admin.require_auth();
-        AccessControl::new(&e).check_admin(&admin);
-
-        put_future_token_share(&e, contract);
-    }
-
-    fn migrate_share_balances(e: Env, operator: Address, users: Vec<Address>) {
-        operator.require_auth();
-        AccessControl::new(&e).check_operator(&operator);
-
-        for user in users {
-            replicate_token_share_balance_to_future(&e, &user);
-        }
-    }
-
-    // Returns the future share token address.
-    fn get_future_share_id(e: Env) -> Address {
-        match get_future_token_share(&e) {
-            Some(address) => address,
-            None => panic_with_error!(e, LiquidityPoolError::FutureShareIdNotSet),
-        }
-    }
-
-    // Applies the future share token instead of the current one.
-    fn commit_future_share_id(e: Env, admin: Address) {
-        admin.require_auth();
-        AccessControl::new(&e).check_admin(&admin);
-
-        commit_future_token_share(&e);
     }
 }
 

--- a/liquidity_pool_stableswap/src/pool_interface.rs
+++ b/liquidity_pool_stableswap/src/pool_interface.rs
@@ -95,10 +95,6 @@ pub trait UpgradeableContractTrait {
 
 pub trait UpgradeableLPTokenTrait {
     fn upgrade_token(e: Env, admin: Address, new_token_wasm: BytesN<32>);
-    fn set_future_share_id(e: Env, admin: Address, contract: Address);
-    fn migrate_share_balances(e: Env, operator: Address, users: Vec<Address>);
-    fn get_future_share_id(e: Env) -> Address;
-    fn commit_future_share_id(e: Env, admin: Address);
 }
 
 pub trait RewardsTrait {

--- a/token_share/src/lib.rs
+++ b/token_share/src/lib.rs
@@ -10,7 +10,6 @@ use utils::bump::bump_instance;
 #[contracttype]
 enum DataKey {
     TokenShare,
-    FutureTokenShare,
     TotalShares,
 }
 
@@ -66,46 +65,4 @@ pub fn mint_shares(e: &Env, to: &Address, amount: i128) {
 
     let share_contract_id = get_token_share(e);
     SorobanTokenAdminClient::new(e, &share_contract_id).mint(to, &amount);
-}
-
-// share token migration functionality
-pub fn get_future_token_share(e: &Env) -> Option<Address> {
-    bump_instance(e);
-    e.storage().instance().get(&DataKey::FutureTokenShare)
-}
-
-pub fn put_future_token_share(e: &Env, contract: Address) {
-    bump_instance(e);
-    e.storage()
-        .instance()
-        .set(&DataKey::FutureTokenShare, &contract);
-}
-
-// migrate user share balance to new token share contract
-pub fn replicate_token_share_balance_to_future(e: &Env, user: &Address) {
-    let future_token_share = match get_future_token_share(e) {
-        Some(address) => address,
-        None => return,
-    };
-
-    let share_token_balance = SorobanTokenClient::new(e, &get_token_share(e)).balance(user);
-    let future_share_token_balance = SorobanTokenClient::new(e, &future_token_share).balance(user);
-    if share_token_balance > future_share_token_balance {
-        let diff = share_token_balance - future_share_token_balance;
-        SorobanTokenAdminClient::new(e, &future_token_share).mint(user, &diff);
-    } else if share_token_balance < future_share_token_balance {
-        let diff = future_share_token_balance - share_token_balance;
-        SorobanTokenClient::new(e, &future_token_share).burn(user, &diff);
-    }
-}
-
-// replace token share with future token share when migration is done
-pub fn commit_future_token_share(e: &Env) {
-    let future_token_share = match get_future_token_share(e) {
-        Some(address) => address,
-        None => panic_with_error!(e, StorageError::ValueNotInitialized),
-    };
-
-    put_token_share(e, future_token_share);
-    e.storage().instance().remove(&DataKey::FutureTokenShare);
 }


### PR DESCRIPTION
removed unneeded LP token migration code since all pools already migrated and all LP tokens are upgradeable