### PR TITLE
[Bugfix] Set pool decimals if entry not set yet

### DIFF
--- a/liquidity_pool_stableswap/src/contract.rs
+++ b/liquidity_pool_stableswap/src/contract.rs
@@ -20,7 +20,7 @@ use token_share::{
 
 use crate::errors::LiquidityPoolError;
 use crate::events::Events;
-use crate::normalize::xp;
+use crate::normalize::{read_decimals, xp};
 use crate::plane::update_plane;
 use crate::plane_interface::Plane;
 use crate::rewards::get_rewards_manager;
@@ -1034,17 +1034,7 @@ impl LiquidityPoolInterfaceTrait for LiquidityPool {
         put_fee(&e, &fee);
 
         put_tokens(&e, &tokens);
-
-        let mut decimals: Vec<u32> = Vec::new(&e);
-
-        for token in tokens.iter() {
-            // get coin decimals
-            let token_client = SorobanTokenClient::new(&e, &token);
-            let decimal = token_client.decimals();
-            decimals.push_back(decimal);
-        }
-
-        put_decimals(&e, &decimals);
+        put_decimals(&e, &read_decimals(&e, &tokens));
 
         // LP token
         let share_contract = create_contract(&e, token_wasm_hash, &tokens);

--- a/liquidity_pool_stableswap/src/normalize.rs
+++ b/liquidity_pool_stableswap/src/normalize.rs
@@ -1,6 +1,20 @@
 use crate::storage::get_decimals;
 use soroban_fixed_point_math::SorobanFixedPoint;
-use soroban_sdk::{Env, Vec};
+use soroban_sdk::token::Client as SorobanTokenClient;
+use soroban_sdk::{Address, Env, Vec};
+
+// Get decimals for all pool tokens
+pub fn read_decimals(e: &Env, tokens: &Vec<Address>) -> Vec<u32> {
+    let mut decimals: Vec<u32> = Vec::new(&e);
+
+    for token in tokens.iter() {
+        // get coin decimals
+        let token_client = SorobanTokenClient::new(&e, &token);
+        let decimal = token_client.decimals();
+        decimals.push_back(decimal);
+    }
+    decimals
+}
 
 // Target precision for internal calculations. It's the maximum precision of all tokens.
 pub fn get_precision(decimals: &Vec<u32>) -> u128 {

--- a/liquidity_pool_stableswap/src/storage.rs
+++ b/liquidity_pool_stableswap/src/storage.rs
@@ -67,7 +67,11 @@ pub fn get_decimals(e: &Env) -> Vec<u32> {
     bump_instance(e);
     match e.storage().instance().get(&DataKey::Decimals) {
         Some(v) => v,
-        None => panic_with_error!(e, StorageError::ValueNotInitialized),
+        None => {
+            let decimals = normalize::read_decimals(e, &get_tokens(e));
+            put_decimals(e, &decimals);
+            decimals
+        }
     }
 }
 


### PR DESCRIPTION
H-03 adds methods that rely on `decimals` entry. however, it's being set only during initialization, which breaks existing pools