### PR TITLE
Fix multiplication overflow for rates

### DIFF
--- a/liquidity_pool_stableswap/src/normalize.rs
+++ b/liquidity_pool_stableswap/src/normalize.rs
@@ -32,29 +32,12 @@ pub fn get_precision_mul(e: &Env, decimals: &Vec<u32>) -> Vec<u128> {
     precision_mul
 }
 
-// Adjust token amounts for decimal differences
-pub fn get_rates(e: &Env, decimals: &Vec<u32>) -> Vec<u128> {
-    let mut rates = Vec::new(e);
-    let precision = get_precision(&decimals);
-    for precision_mul in get_precision_mul(e, &decimals) {
-        rates.push_back(precision * precision_mul);
-    }
-    rates
-}
-
 // Reserves in normalized form (scaled to `Precision`)
 pub fn xp(e: &Env, reserves: &Vec<u128>) -> Vec<u128> {
     let decimals = get_decimals(e);
-    let precision = get_precision(&decimals);
-    let mut result = get_rates(e, &decimals);
+    let mut result = get_precision_mul(e, &decimals);
     for i in 0..result.len() {
-        result.set(
-            i,
-            result
-                .get(i)
-                .unwrap()
-                .fixed_mul_floor(e, &reserves.get(i).unwrap(), &precision),
-        )
+        result.set(i, result.get(i).unwrap() * reserves.get(i).unwrap())
     }
     result
 }

--- a/liquidity_pool_stableswap/src/storage.rs
+++ b/liquidity_pool_stableswap/src/storage.rs
@@ -34,7 +34,6 @@ enum DataKey {
     // Tokens precision
     Precision, // target precision for internal calculations. It's the maximum precision of all tokens.
     PrecisionMul, // Scales raw token amounts to match `Precision`, accounting for decimal differences.
-    Rates,        // adjust token amounts for decimal differences
 }
 
 generate_instance_storage_getter_and_setter_with_default!(
@@ -266,24 +265,6 @@ pub fn get_precision_mul(e: &Env) -> Vec<u128> {
             let precision_mul = normalize::get_precision_mul(e, &get_decimals(e));
             set_precision_mul(e, &precision_mul);
             precision_mul
-        }
-    }
-}
-
-// Rates - adjust token amounts for decimal differences
-pub fn set_rates(e: &Env, value: &Vec<u128>) {
-    bump_instance(e);
-    e.storage().instance().set(&DataKey::Rates, value);
-}
-
-pub fn get_rates(e: &Env) -> Vec<u128> {
-    bump_instance(e);
-    match e.storage().instance().get(&DataKey::Rates) {
-        Some(v) => v,
-        None => {
-            let rates = normalize::get_rates(e, &get_decimals(e));
-            set_rates(e, &rates);
-            rates
         }
     }
 }


### PR DESCRIPTION
get rid of rates in favor of precision_mul to avoid early math overflow